### PR TITLE
Update build docs and s2e-config-template.lua files in examples

### DIFF
--- a/Documentation/Build.md
+++ b/Documentation/Build.md
@@ -8,8 +8,19 @@ S2E officially supports 64-bit Ubuntu (18.04, 20.04 LTS), older or later version
 
 You need to manually install some additional tools or packages before building CRAX++.
 * [pwntools](https://github.com/Gallopsled/pwntools) (4.7.0)
+```
+sudo -H python3 -m pip install pwntools==4.7.0
+```
+
 * [pybind11-dev](https://github.com/pybind/pybind11) (2.4.3-2build2)
+```
+sudo apt-get install pybind11-dev=2.4.3-2build2
+```
+
 * [ROPgadget](https://github.com/JonathanSalwan/ROPgadget) (6.6)
+```
+sudo -H python3 -m pip install ROPgadget==6.6
+```
 
 ## Building S2E Manually
 
@@ -78,23 +89,20 @@ cd ~/s2e/source/CRAXplusplus/proxies/sym_file && make
 
 Create an S2E project with our concolic execution proxy, `sym_stdin`.
 ```
-cd ~/s2e/source/s2e/proxies/sym_stdin
-make
 cd ~/s2e
 s2e new_project --image debian-9.2.1-x86_64 ~/s2e/source/CRAXplusplus/proxies/sym_stdin/sym_stdin
 ```
 
-Run `setup.sh`. This applies several patches to the S2E source tree, and places some symlinks in your S2E project.
+Run `setup.sh`. This applies several patches to the S2E source tree, places some symlinks in your S2E project, and merges the source code of CRAX++ into S2E source tree.
 ```
 cd ~/s2e/source/CRAXplusplus
 ./setup.sh
 ```
 
-Merge the source code of CRAX++ into S2E source tree, and rebuild S2E.
+Rebuild S2E.
 ```
-rm -rf ~/s2e/source/s2e/libs2eplugins/src/s2e/Plugins/CRAX
-cp -ar ~/s2e/source/CRAXplusplus/src ~/s2e/source/s2e/libs2eplugins/src/s2e/Plugins/CRAX
 cd ~/s2e
+rm -rf build/stamps/libs2e-release-*
 s2e build
 ```
 
@@ -141,7 +149,7 @@ Modify `s2e-config.template.lua` and tailor the exploitation techniques to your 
 techniques = {
     "Ret2csu",
     "BasicStackPivot",
-    "GotPartialOverwrite",
+    "Ret2syscall",
 },
 ```
 

--- a/examples/BID-8901-iwconfig/s2e-config.template.lua
+++ b/examples/BID-8901-iwconfig/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_arg",
+        os.getenv("HOME") .. "/s2e/projects/sym_arg",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_arg",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_arg",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/CVE-2001-1413-ncompress/s2e-config.template.lua
+++ b/examples/CVE-2001-1413-ncompress/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_arg",
+        os.getenv("HOME") .. "/s2e/projects/sym_arg",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_arg",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_arg",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/CVE-2004-2093-rsync/s2e-config.template.lua
+++ b/examples/CVE-2004-2093-rsync/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_env",
+        os.getenv("HOME") .. "/s2e/projects/sym_env",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_env",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_env",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/CVE-2017-14493-dnsmasq-aslr-nx/s2e-config.template.lua
+++ b/examples/CVE-2017-14493-dnsmasq-aslr-nx/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_socket",
+        os.getenv("HOME") .. "/s2e/projects/sym_socket",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_socket",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_socket",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/CVE-2017-14493-dnsmasq/s2e-config.template.lua
+++ b/examples/CVE-2017-14493-dnsmasq/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_socket",
+        os.getenv("HOME") .. "/s2e/projects/sym_socket",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_socket",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_socket",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/OSVDB-ID-16373-glftpd/s2e-config.template.lua
+++ b/examples/OSVDB-ID-16373-glftpd/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_arg",
+        os.getenv("HOME") .. "/s2e/projects/sym_arg",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_arg",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_arg",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/actf2020-no_canary/s2e-config.template.lua
+++ b/examples/actf2020-no_canary/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/actf2021-tranquil/s2e-config.template.lua
+++ b/examples/actf2021-tranquil/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/aslr-nx-canary/s2e-config.template.lua
+++ b/examples/aslr-nx-canary/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/aslr-nx-pie-alt1/s2e-config.template.lua
+++ b/examples/aslr-nx-pie-alt1/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/aslr-nx-pie-canary-fullrelro-trans/s2e-config.template.lua
+++ b/examples/aslr-nx-pie-canary-fullrelro-trans/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/aslr-nx-pie-canary-fullrelro/s2e-config.template.lua
+++ b/examples/aslr-nx-pie-canary-fullrelro/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/aslr-nx-pie-canary/s2e-config.template.lua
+++ b/examples/aslr-nx-pie-canary/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/aslr-nx-pie/s2e-config.template.lua
+++ b/examples/aslr-nx-pie/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/aslr-nx/s2e-config.template.lua
+++ b/examples/aslr-nx/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/defcon27-quals-speedrun-002/s2e-config.template.lua
+++ b/examples/defcon27-quals-speedrun-002/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/ntucs2017-readme/s2e-config.template.lua
+++ b/examples/ntucs2017-readme/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/ntucs2017-readme_alt1/s2e-config.template.lua
+++ b/examples/ntucs2017-readme_alt1/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/ntucs2017-readme_alt2/s2e-config.template.lua
+++ b/examples/ntucs2017-readme_alt2/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/pwnable-kr-bof/s2e-config.template.lua
+++ b/examples/pwnable-kr-bof/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/pwnable-kr-unexploitable/s2e-config.template.lua
+++ b/examples/pwnable-kr-unexploitable/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/pwnable-tw-unexploitable-trans/s2e-config.template.lua
+++ b/examples/pwnable-tw-unexploitable-trans/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/pwnable-tw-unexploitable/s2e-config.template.lua
+++ b/examples/pwnable-tw-unexploitable/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/rop-emporium-callme/s2e-config.template.lua
+++ b/examples/rop-emporium-callme/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/rop-emporium-ret2win/s2e-config.template.lua
+++ b/examples/rop-emporium-ret2win/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/examples/rop-emporium-split/s2e-config.template.lua
+++ b/examples/rop-emporium-split/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/proxies/sym_arg/s2e-config.template.lua
+++ b/proxies/sym_arg/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_arg",
+        os.getenv("HOME") .. "/s2e/projects/sym_arg",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_arg",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_arg",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/proxies/sym_env/s2e-config.template.lua
+++ b/proxies/sym_env/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_env",
+        os.getenv("HOME") .. "/s2e/projects/sym_env",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_env",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_env",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/proxies/sym_file/s2e-config.template.lua
+++ b/proxies/sym_file/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_file",
+        os.getenv("HOME") .. "/s2e/projects/sym_file",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_file",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_file",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/proxies/sym_socket/s2e-config.template.lua
+++ b/proxies/sym_socket/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_socket",
+        os.getenv("HOME") .. "/s2e/projects/sym_socket",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_socket",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_socket",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 

--- a/proxies/sym_stdin/s2e-config.template.lua
+++ b/proxies/sym_stdin/s2e-config.template.lua
@@ -49,7 +49,7 @@ pluginsConfig.BaseInstructions = {
 add_plugin("HostFiles")
 pluginsConfig.HostFiles = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
     },
     allowWrite = true,
 }
@@ -63,8 +63,8 @@ pluginsConfig.HostFiles = {
 add_plugin("Vmi")
 pluginsConfig.Vmi = {
     baseDirs = {
-        "/home/aesophor/s2e/projects/sym_stdin",
-        "/home/aesophor/s2e/images/debian-9.2.1-x86_64/guestfs",
+        os.getenv("HOME") .. "/s2e/projects/sym_stdin",
+        os.getenv("HOME") .. "/s2e/images/debian-9.2.1-x86_64/guestfs",
     },
 }
 


### PR DESCRIPTION
After #11 , I update the build docs to avoid people going the wrong way like me.

The paths in the s2e-config-template.lua files in examples are hardcoded, this PR also fix this problem.

For example:
```
add_plugin("HostFiles")
pluginsConfig.HostFiles = {
    baseDirs = {
        "/home/aesophor/s2e/projects/sym_stdin"
    },
    allowWrite = true,
}
```

The code above is updated to:
```
add_plugin("HostFiles")
pluginsConfig.HostFiles = {
    baseDirs = {
        os.getenv("HOME") .. "/s2e/projects/sym_stdin"
    },
    allowWrite = true,
}
```